### PR TITLE
Make --help the default command

### DIFF
--- a/lib/yu.rb
+++ b/lib/yu.rb
@@ -18,6 +18,8 @@ module Yu
       program :version, VERSION
       program :description, 'A container framework based on docker-compose'
 
+      default_command :help
+
       command :test do |c|
         c.syntax = 'yu test'
         c.description = 'Run tests for service(s)'

--- a/lib/yu/version.rb
+++ b/lib/yu/version.rb
@@ -1,3 +1,3 @@
 module Yu
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Shows the help menu when a command is missing. Simples
