### PR TITLE
Ruby 2.0.0 compatibility

### DIFF
--- a/lib/yu.rb
+++ b/lib/yu.rb
@@ -220,7 +220,9 @@ module Yu
       service_names.select { |service_name| Pathname(service_name).exist? }
     end
 
-    def copy_template_into_dir(service_name:)
+    def copy_template_into_dir(options={})
+      service_name = options.fetch(:service_name)
+
       run_command("cp -aR #{template_dir} #{service_name}")
     end
 

--- a/lib/yu/version.rb
+++ b/lib/yu/version.rb
@@ -1,3 +1,3 @@
 module Yu
-  VERSION = "0.2.3"
+  VERSION = "0.2.5"
 end


### PR DESCRIPTION
Provide backwards compatibility to allow running yu on ruby 2.0.0.
